### PR TITLE
Fix supabase server client cookie handling

### DIFF
--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -43,7 +43,7 @@ function toUserResponse(user: {
 }
 
 export async function GET() {
-  const supabase = createSupabaseServer();
+  const supabase = await createSupabaseServer();
   const {
     data: { user: sUser },
   } = await supabase.auth.getUser();

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
     normalizedGender = trimmedGender as "Male" | "Female";
   }
 
-  const supabase = createSupabaseServer();
+  const supabase = await createSupabaseServer();
 
   try {
     const { data: signUpData, error: signUpError } = await supabase.auth.signUp({

--- a/web/src/app/api/auth/signin/route.ts
+++ b/web/src/app/api/auth/signin/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "missing fields" }, { status: 400 });
   }
 
-  const supabase = createSupabaseServer();
+  const supabase = await createSupabaseServer();
   const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
     email: normalizedEmail,
     password: normalizedPassword,

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -22,8 +22,8 @@ function assertClientEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABAS
   return value;
 }
 
-export function createSupabaseServer() {
-  const cookieStore = cookies();
+export async function createSupabaseServer() {
+  const cookieStore = await cookies();
   const supabaseUrl =
     resolveServerEnv("NEXT_PUBLIC_SUPABASE_URL", [
       "DATABASE_SUPABASE_URL",


### PR DESCRIPTION
## Summary
- await the Next.js cookies helper in `createSupabaseServer` so the Turbopack build sees the resolved store
- update API routes that build a server Supabase client to await the async factory

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d711d76530832aba73195e26b4fb52